### PR TITLE
Misc fixes

### DIFF
--- a/adminzone/pages/modules/admin_setupwizard.php
+++ b/adminzone/pages/modules/admin_setupwizard.php
@@ -978,7 +978,7 @@ class Module_admin_setupwizard
             if (!file_exists(get_file_base() . '/.git')) { // Only uninstall if we're not working from a git repository
                 foreach ($uninstalling as $addon_info) {
                     // Archive it off to exports/addons
-                    if ($addon_info['addon_files'] != array()) {
+                    if ($addon_info['files'] != array()) {
                         $file = preg_replace('#^[\_\.\-]#', 'x', preg_replace('#[^\w\.\-]#', '_', $addon_info['name'])) . '.tar';
                         create_addon(
                             $file,

--- a/sources_custom/hooks/systems/addon_registry/composr_homesite.php
+++ b/sources_custom/hooks/systems/addon_registry/composr_homesite.php
@@ -159,7 +159,6 @@ class Hook_addon_registry_composr_homesite
             'themes/default/templates_custom/CMS_SITE.tpl',
             'themes/default/templates_custom/CMS_SITES_SCREEN.tpl',
             'uploads/website_specific/compo.sr/.htaccess',
-            'uploads/website_specific/compo.sr/logos',
             'uploads/website_specific/compo.sr/logos/a.png',
             'uploads/website_specific/compo.sr/logos/b.png',
             'uploads/website_specific/compo.sr/logos/choice.php',

--- a/sources_custom/hooks/systems/addon_registry/composr_release_build.php
+++ b/sources_custom/hooks/systems/addon_registry/composr_release_build.php
@@ -138,7 +138,6 @@ class Hook_addon_registry_composr_release_build
             'adminzone/pages/minimodules_custom/push_bugfix.php',
             'adminzone/pages/minimodules_custom/plug_guid.php',
             'exports/builds/index.html',
-            'data_custom/builds',
             'data_custom/builds/index.html',
             'data_custom/builds/readme.txt',
         );


### PR DESCRIPTION
Undefined index error: addon_files in admin_setupwizard.php. Directories
defined as addon files in add_registry hook for composr_homesite and
composr_release_build addons were causing an error in the addon
uninstall part of the Setup Wizard.