### PR TITLE
Misc fixes

### DIFF
--- a/adminzone/pages/modules/admin_cns_members.php
+++ b/adminzone/pages/modules/admin_cns_members.php
@@ -82,7 +82,9 @@ class Module_admin_cns_members
             //$ret['_SEARCH:admin_cns_groups:browse']=array('USERGROUPS','menu/social/groups');
             //if (addon_installed('staff'))
             // $ret['_SEARCH:admin_staff:browse']=array('STAFF','menu/site_meta/staff');
-            $ret['_SEARCH:warnings:edit'] = array('WARNINGS', 'tabs/member_account/warnings');
+            if (addon_installed('warnings')) {
+                $ret['_SEARCH:warnings:edit'] = array('WARNINGS', 'tabs/member_account/warnings');
+            }
         }
 
         return $ret;

--- a/sources/addons2.php
+++ b/sources/addons2.php
@@ -707,12 +707,12 @@ function uninstall_addon($addon)
 
                 $matches = array();
                 if (preg_match('#([^/]*)/?pages/modules(_custom)?/(.*)\.php#', $filename, $matches) != 0) {
-                    if ($matches[2] != '_custom' || !is_file(get_file_base() . '/' . $filename)) {
+                    if ($matches[2] != '_custom' || ($matches[2] == '_custom' && !is_file(get_file_base() . '/' . str_replace('_custom/', '/', $filename)))) {
                         uninstall_module($matches[1], $matches[3]);
                     }
                 }
                 if (preg_match('#sources(_custom)?/blocks/(.*)\.php#', $filename, $matches) != 0) {
-                    if ($matches[1] != '_custom' || !is_file(get_file_base() . '/' . $filename)) {
+                    if ($matches[1] != '_custom' || ($matches[1] == '_custom' && !is_file(get_file_base() . '/' . str_replace('_custom/', '/', $filename)))) {
                         uninstall_block($matches[2]);
                     }
                 }

--- a/sources/css_and_js.php
+++ b/sources/css_and_js.php
@@ -197,7 +197,7 @@ function js_compile($j, $js_cache_path, $minify = true)
 function compress_cms_stub_file($stub_file)
 {
     if (function_exists('gzencode')) {
-        $myfile = @fopen($stub_file . '.gz', GOOGLE_APPENGINE ? 'wb' : 'at');
+        $myfile = @fopen($stub_file . '.gz', GOOGLE_APPENGINE ? 'wb' : 'ab');
         if ($myfile !== false) {
             $compressed = gzencode(file_get_contents($stub_file), 9);
 


### PR DESCRIPTION
Fix error when warnings addon is uninstalled. Tweak to block and module
uninstall logic so _custom modules and blocks also get their uninstall()
function called. Fix for corrupted pre-compressed css and js files.