### PR TITLE
Misc fixes

### DIFF
--- a/cms/pages/modules/cms_comcode_pages.php
+++ b/cms/pages/modules/cms_comcode_pages.php
@@ -603,7 +603,7 @@ class Module_cms_comcode_pages
     public function find_comcode_page($lang, $file, $zone)
     {
         $restore_from = zone_black_magic_filterer(filter_naughty(get_param_string('restore_from', $zone . '/' . 'pages/comcode_custom/' . $lang . '/' . $file . '.txt')), true);
-		if (((!is_file(get_file_base() . '/' . $restore_from)) && (!is_file(get_custom_file_base() . '/' . $restore_from))) || ((!is_null(get_param('restore_from', null))) && (!$GLOBALS['FORUM_DRIVER']->is_staff(get_member())))) {
+		if (((!is_file(get_file_base() . '/' . $restore_from)) && (!is_file(get_custom_file_base() . '/' . $restore_from))) || ((!is_null(get_param_string('restore_from', null))) && (!$GLOBALS['FORUM_DRIVER']->is_staff(get_member())))) {
 			$page_request = _request_page($file, $zone);
 			if (strpos($page_request[0], 'COMCODE') === false) {
                 return '';

--- a/sources_custom/miniblocks/main_calculator.php
+++ b/sources_custom/miniblocks/main_calculator.php
@@ -17,14 +17,14 @@ $equation = str_replace('math.', 'Math.', strtolower($equation)); // Name fields
 echo '<form onsubmit="event.returnValue=false; return false;" action="#" method="post">';
 foreach ($map as $key => $val) {
     $key = strtolower($key); // Firefox forces this, but we'll force it too just in case of browser inconsistency
-    if (($key != 'equation') && ($key != 'block') && ($key != 'message')) {
+    if (($key != 'equation') && ($key != 'block') && ($key != 'message') && ($key != 'cache')) {
         echo '<p>
             <input class="input_integer_required right" size="6" type="text" id="' . escape_html($key) . '" name="' . escape_html($key) . '" value="" />
             <label class="field_title" for="' . escape_html($key) . '">' . escape_html($val) . '</label>
         </p>';
     }
 }
-$uniqid = uniqid('', true);
+$uniqid = str_replace('.', '_', uniqid('', true));
 echo '
     <script>
         function calculate_sum_' . $uniqid . '(elements)


### PR DESCRIPTION
Fix for stack trace when opening panel for full page editing. A fix for
issue 1968 (http://ocportal.com/tracker/view.php?id=1968) and one
additional issue where an extra form field was added due to cache being
in the $map array.