### PR TITLE
Fix news entries count in news category boxes

### DIFF
--- a/sources/news.php
+++ b/sources/news.php
@@ -180,7 +180,7 @@ function render_news_category_box($row, $zone = '_SEARCH', $give_context = true,
     $title = $give_context ? do_lang('CONTENT_IS_OF_TYPE', do_lang('NEWS_CATEGORY'), $_title) : $_title;
 
     // Metadata
-    $num_entries = $GLOBALS['SITE_DB']->query_select_value('news', 'COUNT(*)', array('validated' => 1));
+    $num_entries = $GLOBALS['SITE_DB']->query_select_value('news', 'COUNT(*)', array('validated' => 1, 'news_category' => $row['id']));
     $entry_details = do_lang_tempcode('CATEGORY_SUBORDINATE_2', escape_html(integer_format($num_entries)));
 
     // Image


### PR DESCRIPTION
The news entries count for news categories was displaying the total combined validated news entries count for all news categories. Now it will display the validated news entries count of just the category for which the box is being rendered.